### PR TITLE
Feature/methods describer

### DIFF
--- a/src/descriptor.jl
+++ b/src/descriptor.jl
@@ -59,7 +59,7 @@ function methodsFilter(methods::MethodDescriberSet, parameters::Union{Pair, Arra
     return MethodDescriberSet(collect(filtered_methods))
 end
 
-methodsFilter(parameters::Union{Pair, Array{Pair}}) = (METHODS, parameters)
+methodsFilter(parameters::Union{Pair, Array{Pair}}) = methodsFilter(METHODS, parameters)
 
 function Base.show(io::IO, methods::MethodDescriberSet)
     for method in methods.describers

--- a/src/descriptor.jl
+++ b/src/descriptor.jl
@@ -36,13 +36,38 @@ end
 
 MethodDescriberSet(args...) = MethodDescriberSet([args...])
 
+function methodsFilter(methods::MethodDescriberSet, parameters::Union{Pair, Array{Pair}})
+    if !(parameters isa Array)
+        parameters = [parameters]
+    end
+
+    filtered_methods = Set()
+    
+    for parameter in parameters
+        if !(parameter[1] in fieldnames(MethodDescriber))
+            @warn "$(parameter[1]) isn't a property of MethodDescriber"
+            continue
+        end
+        for method in methods.describers 
+            property = getfield(method, parameter[1])
+            if property == parameter[2]
+                push!(filtered_methods, method)
+            end
+        end
+    end
+
+    return MethodDescriberSet(collect(filtered_methods))
+end
+
+methodsFilter(parameters::Union{Pair, Array{Pair}}) = (METHODS, parameters)
+
 function Base.show(io::IO, methods::MethodDescriberSet)
     for method in methods.describers
         println(method)
     end
 end
 
-_methods = MethodDescriberSet(
+const METHODS = MethodDescriberSet(
     MethodDescriber(
         "Generate_blobs",
         n_features = :Dynamic,
@@ -55,4 +80,4 @@ _methods = MethodDescriberSet(
         problem_type = :Regression),
 )
 
-methods() = println(_methods)
+methods() = println(METHODS)

--- a/src/descriptor.jl
+++ b/src/descriptor.jl
@@ -1,0 +1,54 @@
+mutable struct MethodDescriber
+    name::String
+    n_features::Union{Symbol, Int, Nothing}
+    n_samples::Union{Symbol, Int, Nothing}
+    problem_type::Union{Symbol, Nothing}
+
+    MethodDescriber() = new()
+    
+end
+
+function MethodDescriber(   method_name::String;
+                            n_features = nothing,
+                            n_samples = nothing,
+                            problem_type = nothing)
+    
+    method = MethodDescriber()
+
+    method.name = method_name
+    method.n_features = n_features
+    method.n_samples = n_samples
+    method.problem_type = problem_type
+
+    return method
+end 
+
+function Base.show(io::IO, method::MethodDescriber)
+    println("# $(method.name)")
+    method.n_features !== nothing && println("number of features: " * string(method.n_features))
+    method.n_samples !== nothing && println("amount of samples: " * string(method.n_samples))
+    method.problem_type !== nothing && println("problem type: " * string(method.problem_type))
+end
+
+MethodsDescriber(args...) = MethodDescriber[args...]
+
+function Base.show(io::IO, methods::Array{MethodDescriber})
+    for method in methods
+        println(method)
+    end
+end
+
+_methods = MethodsDescriber(
+    MethodDescriber(
+        "Generate_blobs",
+        n_features = :Dynamic,
+        n_samples = :Dynamic,
+        problem_type = :Classification),
+    MethodDescriber(
+        "Generate_s_curve",
+        n_features = 2,
+        n_samples = :Dynamic,
+        problem_type = :Regression),
+)
+
+methods() = println(_methods)

--- a/src/descriptor.jl
+++ b/src/descriptor.jl
@@ -30,15 +30,19 @@ function Base.show(io::IO, method::MethodDescriber)
     method.problem_type !== nothing && println("problem type: " * string(method.problem_type))
 end
 
-MethodsDescriber(args...) = MethodDescriber[args...]
+mutable struct MethodDescriberSet
+    describers::Array{MethodDescriber, 1}
+end
 
-function Base.show(io::IO, methods::Array{MethodDescriber})
-    for method in methods
+MethodDescriberSet(args...) = MethodDescriberSet([args...])
+
+function Base.show(io::IO, methods::MethodDescriberSet)
+    for method in methods.describers
         println(method)
     end
 end
 
-_methods = MethodsDescriber(
+_methods = MethodDescriberSet(
     MethodDescriber(
         "Generate_blobs",
         n_features = :Dynamic,


### PR DESCRIPTION
Neste PR está a primeira definição do que seria o descritor dos métodos junto a uma função que possibilita a filtragem dos métodos com base nas características desejadas.
Alguns exemplos do uso dessa função:
```julia
###Comando
methodsFilter(:problem_type => :Classification)
###Output
# Generate_blobs
number of features: Dynamic
amount of samples: Dynamic
problem type: Classification
```

```julia
###Comando
methodsFilter(:problem_type => :Regression)
###Output
# Generate_s_curve
number of features: 2
amount of samples: Dynamic
problem type: Regression
```

```julia
###Comando
methodsFilter(:problem_typee => :Classification)
###Output
┌ Warning: problem_typee isn't a property of MethodDescriber
└ @ Main ~/Codes/JULIA/SyntheticDatasets.jl/src/descriptor.jl:48
```
Para adição de mais características na filtragem é só usar como argumento um array de pares.
```julia
methodsFilter([problem_type => :Classification, n_features => :Dynamic])
```