### PR TITLE
[#40] - Convert function problem

### DIFF
--- a/src/SyntheticDatasets.jl
+++ b/src/SyntheticDatasets.jl
@@ -31,4 +31,22 @@ function convert(features::Array{T, 2}, labels::Array{D, 1})::DataFrame where {T
     return df
 end
 
+function convert(features::Array{T, 2}, labels::Array{D, 2})::DataFrame where {T <: Number, D <: Number}
+    df = DataFrame()
+
+    for i = 1:size(features)[2]
+        df[!, Symbol("feature_$(i)")] = eltype(features)[]
+    end
+
+    for i = 1:size(labels)[2]
+        df[!, Symbol("label_$(i)")] = eltype(labels)[]
+    end
+    
+    for row in 1:size(features)[1]
+        push!(df, (features[row, :]... , labels[row, :]...))
+    end
+    
+    return df
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,24 @@ using Test
     @test size(data)[1] == samples
     @test size(data)[2] == features + 1
 
+    data = SyntheticDatasets.make_regression(   n_samples = samples,
+                                                n_features = features,
+                                                n_targets = 2,
+                                                noise = 2.2,
+                                                random_state = 5)
+
+    @test size(data)[1] == samples
+    @test size(data)[2] == features + 2
+
+    data = SyntheticDatasets.make_regression(   n_samples = samples,
+                                                n_features = features,
+                                                n_targets = 3,
+                                                noise = 2.2,
+                                                random_state = 5)
+
+    @test size(data)[1] == samples
+    @test size(data)[2] == features + 3
+
     data = SyntheticDatasets.make_classification(   n_samples = samples,
                                                     n_features = features,
                                                     n_classes = 1)


### PR DESCRIPTION
A simple way to solve this problem is creating a new `convert` function that is able to receive a two-dimensional array in the `labels`  parameter and that's what I did. But this function isn't arranging the observations like the other function, the one-dimension version arranges together the observations that have the same label, this new function doesn't do that